### PR TITLE
Accessibility testing with Playwright

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -30,8 +30,7 @@ jobs:
         working-directory: qa
 
       - name: Run Playwright tests
-        run: npx playwright test/accessibility
-        working-directory: qa
+        run: npx playwright test tests/accessibility
 
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}

--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -31,6 +31,7 @@ jobs:
 
       - name: Run Playwright tests
         run: npx playwright test tests/accessibility
+        working-directory: qa
 
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}

--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -1,4 +1,4 @@
-name: Browser Tests
+name: Accessibility Tests
 on:
   push:
     branches: [main, master]
@@ -30,7 +30,7 @@ jobs:
         working-directory: qa
 
       - name: Run Playwright tests
-        run: npx playwright test/browser
+        run: npx playwright test/accessibility
         working-directory: qa
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -30,7 +30,7 @@ jobs:
         working-directory: qa
 
       - name: Run Playwright tests
-        run: npx playwright test/browser
+        run: npx playwright test tests/browser
         working-directory: qa
 
       - uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -12,7 +12,14 @@
 
 The browser based tests can be found in the directory named `browser` within the `tests` directory.
 
-## To run all tests
+## To begin
+
+- Install Node.js v20
+- cd qa/
+- npm install
+- npm start
+
+## To run tests
 
 To run the tests using Playwright:
 

--- a/qa/jest.config.ts
+++ b/qa/jest.config.ts
@@ -7,7 +7,7 @@ const config: Config = {
     "^.+\\.ts$": "ts-jest",
   },
   moduleFileExtensions: ["ts", "js"],
-  testMatch: ["**/tests/**/*.spec.ts"],
+  testMatch: ["**/qa/tests/integration/**/*.spec.ts"],
   clearMocks: true,
   collectCoverage: true,
   coverageDirectory: "coverage",

--- a/qa/package-lock.json
+++ b/qa/package-lock.json
@@ -12,6 +12,7 @@
         "packages/*"
       ],
       "dependencies": {
+        "@axe-core/playwright": "^4.10.1",
         "concurrently": "^8.2.2"
       },
       "devDependencies": {
@@ -53,6 +54,18 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.10.1.tgz",
+      "integrity": "sha512-EV5t39VV68kuAfMKqb/RL+YjYKhfuGim9rgIaQ6Vntb2HgaCaau0h98Y3WEUqW1+PbdzxDtDNjFAipbtZuBmEA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.10.2"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2194,6 +2207,15 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/axe-core": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
+      "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -5236,7 +5258,6 @@
       "version": "1.51.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.1.tgz",
       "integrity": "sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/qa/package.json
+++ b/qa/package.json
@@ -18,6 +18,7 @@
     "packages/*"
   ],
   "dependencies": {
+    "@axe-core/playwright": "^4.10.1",
     "concurrently": "^8.2.2"
   },
   "devDependencies": {

--- a/qa/packages/server/lib/fixtures/book-loader.js
+++ b/qa/packages/server/lib/fixtures/book-loader.js
@@ -1,0 +1,6 @@
+export async function loadBooks() {
+  if (process.env.NODE_ENV === "test") {
+    return (await import("./test-books.js")).BOOKS;
+  }
+  return (await import("./dev-books.js")).BOOKS;
+}

--- a/qa/packages/server/lib/fixtures/test-books.js
+++ b/qa/packages/server/lib/fixtures/test-books.js
@@ -1,0 +1,798 @@
+export const BOOKS = [
+  {
+    title: "Harry Potter and the Sorcerer’s Stone (Harry Potter, #1)",
+    author: "J.K. Rowling",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1598823299i/42844155._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/42844155-harry-potter-and-the-sorcerer-s-stone",
+    rating: 4.47,
+  },
+  {
+    title: "The Lightning Thief (Percy Jackson and the Olympians, #1)",
+    author: "Rick Riordan",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1400602609i/28187._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/28187.The_Lightning_Thief",
+    rating: 4.31,
+  },
+  {
+    title: "The Hunger Games (The Hunger Games, #1)",
+    author: "Suzanne Collins",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1586722975i/2767052._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/2767052-the-hunger-games",
+    rating: 4.33,
+  },
+  {
+    title: "Twilight (The Twilight Saga, #1)",
+    author: "Stephenie Meyer",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1700522826i/41865._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/41865.Twilight",
+    rating: 3.65,
+  },
+  {
+    title: "The Giver (The Giver, #1)",
+    author: "Lois Lowry",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1342493368i/3636._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/3636.The_Giver",
+    rating: 4.12,
+  },
+  {
+    title: "The Fault in Our Stars",
+    author: "John Green",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1660273739i/11870085._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/11870085-the-fault-in-our-stars",
+    rating: 4.14,
+  },
+  {
+    title: "City of Bones (The Mortal Instruments, #1)",
+    author: "Cassandra Clare",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1432730315i/256683._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/256683.City_of_Bones",
+    rating: 4.07,
+  },
+  {
+    title: "",
+    author: undefined,
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1618526890i/13335037._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/13335037-divergent",
+    rating: 4.14,
+  },
+  {
+    title: "The Book Thief",
+    author: "Markus Zusak",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1522157426i/19063._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/19063.The_Book_Thief",
+    rating: 4.39,
+  },
+  {
+    title: "To Kill a Mockingbird",
+    author: "Harper Lee",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1553383690i/2657._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/2657.To_Kill_a_Mockingbird",
+    rating: 4.26,
+  },
+  {
+    title: null,
+    author: "Stephen Chbosky",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1650033115i/22628._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/22628.The_Perks_of_Being_a_Wallflower",
+    rating: 4.23,
+  },
+  {
+    title: "The Hobbit (The Lord of the Rings, #0)",
+    author: "J.R.R. Tolkien",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1546071216i/5907._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/5907.The_Hobbit",
+    rating: 4.29,
+  },
+  {
+    title: "Holes (Holes, #1)",
+    author: "Louis Sachar",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1618269830i/38709._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/38709.Holes",
+    rating: null,
+  },
+  {
+    title: "The Outsiders",
+    author: "S.E. Hinton",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1442129426i/231804._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/231804.The_Outsiders",
+    rating: 4.12,
+  },
+  {
+    title: "The Golden Compass (His Dark Materials, #1)",
+    author: "Philip Pullman",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1505766203i/119322._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/119322.The_Golden_Compass",
+    rating: 4.02,
+  },
+  {
+    title: "The Host (The Host, #1)",
+    author: null,
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1318009171i/1656001._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/1656001.The_Host",
+    rating: 3.86,
+  },
+  {
+    title: "Looking for Alaska",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1652042180i/99561._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/99561.Looking_for_Alaska",
+    rating: 3.97,
+  },
+  {
+    title: "Vampire Academy (Vampire Academy, #1)",
+    author: "Richelle Mead",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1361098973i/345627._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/345627.Vampire_Academy",
+    rating: 4.11,
+  },
+  {
+    title: "Eragon (The Inheritance Cycle, #1)",
+    author: "Christopher Paolini",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1366212852i/113436._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/113436.Eragon",
+    rating: 3.95,
+  },
+  {
+    title: "A Wrinkle in Time (Time Quintet, #1)",
+    author: "Madeleine L'Engle",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1507963312i/33574273._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/33574273-a-wrinkle-in-time",
+    rating: 3.98,
+  },
+  {
+    title: "Uglies (Uglies, #1)",
+    author: "Scott Westerfeld",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1654202671i/24770._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/24770.Uglies",
+    rating: 3.85,
+  },
+  {
+    title: "Clockwork Angel (The Infernal Devices, #1)",
+    author: "Cassandra Clare",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1693490271i/7171637._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/7171637-clockwork-angel",
+    rating: 4.31,
+  },
+  {
+    title: "Ella Enchanted (Ella Enchanted, #1)",
+    author: "Gail Carson Levine",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1410727190i/24337._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/24337.Ella_Enchanted",
+    rating: 4.01,
+  },
+  {
+    title: "Bridge to Terabithia",
+    author: "Katherine Paterson",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1532478367i/40940121._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/40940121-bridge-to-terabithia",
+    rating: 4.04,
+  },
+  {
+    title: "Pride and Prejudice",
+    author: "Jane Austen",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1320399351i/1885._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/1885.Pride_and_Prejudice",
+    rating: 4.29,
+  },
+  {
+    title: "Little Women",
+    author: "Louisa May Alcott",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1562690475i/1934._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/1934.Little_Women",
+    rating: 4.15,
+  },
+  {
+    title: "Speak",
+    author: "Laurie Halse Anderson",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1529044298i/39280444._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/39280444-speak",
+    rating: 4.05,
+  },
+  {
+    title: "The Maze Runner (The Maze Runner, #1)",
+    author: "James Dashner",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1375596592i/6186357._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/6186357-the-maze-runner",
+    rating: 4.05,
+  },
+  {
+    title: "Charlotte’s Web",
+    author: "E.B. White",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1628267712i/24178._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/24178.Charlotte_s_Web",
+    rating: 42,
+  },
+  {
+    title: "The Lost Hero (The Heroes of Olympus, #1)",
+    author: "Rick Riordan",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1464201003i/7736182._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/7736182-the-lost-hero",
+    rating: 4.31,
+  },
+  {
+    title: "The Little Prince",
+    author: "Antoine de Saint-Exupéry",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1367545443i/157993._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/157993.The_Little_Prince",
+    rating: 4.32,
+  },
+  {
+    title: "Graceling (Graceling Realm, #1)",
+    author: "Kristin Cashore",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1331548394i/3236307._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/3236307-graceling",
+    rating: 4.07,
+  },
+  {
+    title: "The Bad Beginning (A Series of Unfortunate Events, #1)",
+    author: "Lemony Snicket",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1436737029i/78411._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/78411.The_Bad_Beginning",
+    rating: null,
+  },
+  {
+    title: "Number the Stars",
+    author: "Lois Lowry",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1630542426i/47281._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/47281.Number_the_Stars",
+    rating: 4.18,
+  },
+  {
+    title: "Ender’s Game (Ender's Saga, #1)",
+    rating: 4.31,
+  },
+  {},
+  {
+    title: "Inkheart (Inkworld, #1)",
+    author: "Cornelia Funke",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1538266636i/28194._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/28194.Inkheart",
+    rating: 3.92,
+  },
+  {
+    title: "Hush, Hush (Hush, Hush, #1)",
+    author: "Becca Fitzpatrick",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1358261334i/6339664._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/6339664-hush-hush",
+    rating: 3.93,
+  },
+  {
+    title: "Thirteen Reasons Why",
+    author: "Jay Asher",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1555345043i/29844228._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/29844228-thirteen-reasons-why",
+    rating: 3.85,
+  },
+  {
+    title: "Charlie and the Chocolate Factory (Charlie Bucket, #1)",
+    author: "Roald Dahl",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1309211401i/6310._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/6310.Charlie_and_the_Chocolate_Factory",
+    rating: 4.16,
+  },
+  {
+    title: "Anne of Green Gables (Anne of Green Gables, #1)",
+    author: "L.M. Montgomery",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1615094578i/8127._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/8127.Anne_of_Green_Gables",
+    rating: 4.31,
+  },
+  {
+    title: "The Secret Garden",
+    author: "Frances Hodgson Burnett",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1327873635i/2998._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/2998.The_Secret_Garden",
+    rating: 4.16,
+  },
+  {
+    title: "Artemis Fowl (Artemis Fowl, #1)",
+    author: "Eoin Colfer",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1630661894i/249747._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/249747.Artemis_Fowl",
+    rating: 3.86,
+  },
+  {
+    title: "Stargirl (Stargirl, #1)",
+    author: "Jerry Spinelli",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1335947642i/22232._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/22232.Stargirl",
+    rating: 3.77,
+  },
+  {
+    title: "Island of the Blue Dolphins",
+    author: "Scott O'Dell",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1533405446i/41044096._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/41044096-island-of-the-blue-dolphins",
+    rating: 3.87,
+  },
+  {
+    title: "Tuck Everlasting",
+    author: "Natalie Babbitt",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1661030663i/84981._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/84981.Tuck_Everlasting",
+    rating: 3.9,
+  },
+  {
+    title: "The Sisterhood of the Traveling Pants (Sisterhood, #1)",
+    author: "Ann Brashares",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1461611233i/452306._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/452306.The_Sisterhood_of_the_Traveling_Pants",
+    rating: 3.84,
+  },
+  {
+    title: "Lord of the Flies",
+    author: "William Golding",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1327869409i/7624._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/7624.Lord_of_the_Flies",
+    rating: -3.69,
+  },
+  {
+    title: "The City of Ember (Book of Ember, #1)",
+    author: "Jeanne DuPrau",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1591616783i/307791._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/307791.The_City_of_Ember",
+    rating: 3.89,
+  },
+  {
+    title: "Coraline",
+    author: "Neil Gaiman",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1493497435i/17061._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/17061.Coraline",
+    rating: 4.12,
+  },
+  {
+    title: "Paper Towns",
+    author: "John Green",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1349013610i/6442769._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/6442769-paper-towns",
+    rating: 3.71,
+  },
+  {
+    title: "The Angel Experiment (Maximum Ride, #1)",
+    author: "James Patterson",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1339277875i/13152._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/13152.The_Angel_Experiment",
+    rating: 4.07,
+  },
+  {
+    title: "The Catcher in the Rye",
+    author: "J.D. Salinger",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1398034300i/5107._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/5107.The_Catcher_in_the_Rye",
+    rating: 3.8,
+  },
+  {
+    title: "Marked (House of Night, #1)",
+    author: "P.C. Cast",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1317067002i/30183._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/30183.Marked",
+    rating: 3.81,
+  },
+  {
+    title: "Cinder (The Lunar Chronicles, #1)",
+    author: "Marissa Meyer",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1507557775i/36381037._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/36381037-cinder",
+    rating: 4.13,
+  },
+  {
+    title: "The Phantom Tollbooth",
+    author: "Norton Juster",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1558858485i/378._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/378.The_Phantom_Tollbooth",
+    rating: 4.2,
+  },
+  {
+    title: "Hatchet (Brian's Saga, #1)",
+    author: "Gary Paulsen",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1385297074i/50._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/50.Hatchet",
+    rating: 3.77,
+  },
+  {
+    title: "Shiver (The Wolves of Mercy Falls, #1)",
+    author: "Maggie Stiefvater",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1409283154i/6068551._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/6068551-shiver",
+    rating: 3.76,
+  },
+  {
+    title: "The Princess Bride",
+    author: "William Goldman",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1327903636i/21787._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/21787.The_Princess_Bride",
+    rating: 4.27,
+  },
+  {
+    title: "The Westing Game",
+    author: "Ellen Raskin",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1356850909i/902._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/902.The_Westing_Game",
+    rating: null,
+  },
+  {
+    title: "The Selection (The Selection, #1)",
+    author: "Kiera Cass",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1322103400i/10507293._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/10507293-the-selection",
+    rating: 4.08,
+  },
+  {
+    title: "Just Listen",
+    author: "Sarah Dessen",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1358270741i/51738._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/51738.Just_Listen",
+    rating: 4.05,
+  },
+  {
+    title: "A Little Princess",
+    author: "Frances Hodgson Burnett",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1327868556i/3008._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/3008.A_Little_Princess",
+    rating: 4.22,
+  },
+  {
+    title: "Are You There God? It's Me, Margaret",
+    author: "Judy Blume",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1388356524i/37732._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/37732.Are_You_There_God_It_s_Me_Margaret",
+    rating: 3.94,
+  },
+  {
+    title: "Howl’s Moving Castle (Howl’s Moving Castle, #1)",
+    author: "Diana Wynne Jones",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1630502935i/6294._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/6294.Howl_s_Moving_Castle",
+    rating: 4.29,
+  },
+  {
+    title: "Where the Red Fern Grows",
+    author: "Wilson Rawls",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1518702249i/10365._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/10365.Where_the_Red_Fern_Grows",
+    rating: 4.11,
+  },
+  {
+    title: "Fallen (Fallen, #1)",
+    author: "Lauren Kate",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1440619649i/6487308._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/6487308-fallen",
+  },
+  {
+    title: "Matched (Matched, #1)",
+    author: "Ally Condie",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1367706191i/7735333._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/7735333-matched",
+    rating: 3.63,
+  },
+  {
+    title: "The Truth About Forever",
+    author: "Sarah Dessen",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1362767907i/51737._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/51737.The_Truth_About_Forever",
+    rating: 4.12,
+  },
+  {
+    title:
+      "I'd Tell You I Love You, But Then I'd Have to Kill You (Gallagher Girls, #1)",
+    author: "Ally Carter",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1334491180i/852470._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/852470.I_d_Tell_You_I_Love_You_But_Then_I_d_Have_to_Kill_You",
+    rating: 3.84,
+  },
+  {
+    title: "Princess Academy (Princess Academy, #1)",
+    author: "Shannon Hale",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1349410861i/85990._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/85990.Princess_Academy",
+    rating: "4.03",
+  },
+  {
+    title: "The Curious Incident of the Dog in the Night-Time",
+    author: "Mark Haddon",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1479863624i/1618._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/1618.The_Curious_Incident_of_the_Dog_in_the_Night_Time",
+    rating: 3.89,
+  },
+  {
+    title: "A Great and Terrible Beauty (Gemma Doyle, #1)",
+    author: "Libba Bray",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1284558475i/3682._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/3682.A_Great_and_Terrible_Beauty",
+    rating: 3.79,
+  },
+  {
+    title: "Delirium (Delirium, #1)",
+    author: "Lauren Oliver",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1327890411i/11614718._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/11614718-delirium",
+    rating: 3.95,
+  },
+  {
+    title: "Beautiful Creatures (Caster Chronicles, #1)",
+    author: "Kami Garcia",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1327873282i/6304335._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/6304335-beautiful-creatures",
+    rating: 3.77,
+  },
+  {
+    title: "Because of Winn-Dixie",
+    author: "Kate DiCamillo",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1456871914i/357664._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/357664.Because_of_Winn_Dixie",
+    rating: 4.09,
+  },
+  {
+    title: "Legend (Legend, #1)",
+    author: "Marie Lu",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1501368160i/9275658._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/9275658-legend",
+    rating: 416,
+  },
+  {
+    title: "Black Beauty",
+    author: "Anna Sewell",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1578265482i/3685._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/3685.Black_Beauty",
+    rating: 3.99,
+  },
+  {
+    title: "Pippi Longstocking (Pippi Långstrump, #1)",
+    author: "Astrid Lindgren",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1519300455i/19302._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/19302.Pippi_Longstocking",
+    rating: 4.15,
+  },
+  {
+    title: "Alanna: The First Adventure (Song of the Lioness, #1)",
+    author: "Tamora Pierce",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1388206270i/13831._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/13831.Alanna",
+    rating: 4.27,
+  },
+  {
+    title: "The Goose Girl (The Books of Bayern, #1)",
+    author: "Shannon Hale",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1617553319i/179064._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/179064.The_Goose_Girl",
+    rating: 4.14,
+  },
+  {
+    title: "Watership Down (Watership Down, #1)",
+    author: "Richard  Adams",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1405136931i/76620._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/76620.Watership_Down",
+    rating: 0,
+  },
+  {
+    title: "Where the Sidewalk Ends",
+    author: "Shel Silverstein",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1168052448i/30119._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/30119.Where_the_Sidewalk_Ends",
+    rating: 4.33,
+  },
+  {
+    title: "Sabriel (Abhorsen,  #1)",
+    author: "Garth Nix",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1293655399i/518848._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/518848.Sabriel",
+    rating: 4.17,
+  },
+  {
+    title: "The Graveyard Book",
+    author: "Neil Gaiman",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1531295292i/2213661._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/2213661.The_Graveyard_Book",
+    rating: 4.16,
+  },
+  {
+    title: "Walk Two Moons",
+    author: "Sharon Creech",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1389035862i/53496._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/53496.Walk_Two_Moons",
+    rating: 3.99,
+  },
+  {
+    title: "From the Mixed-Up Files of Mrs. Basil E. Frankweiler",
+    author: "E.L. Konigsburg",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1327784751i/3980._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/3980.From_the_Mixed_Up_Files_of_Mrs_Basil_E_Frankweiler",
+    rating: 4.16,
+  },
+  {
+    title: "Go Ask Alice",
+    author: "Beatrice Sparks",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1327870536i/46799._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/46799.Go_Ask_Alice",
+    rating: 3.74,
+  },
+  {
+    title: "Fablehaven (Fablehaven, #1)",
+    author: "Brandon Mull",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1460309528i/44652._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/44652.Fablehaven",
+    rating: 4.13,
+  },
+  {
+    title: "Flipped",
+    author: "Wendelin Van Draanen",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1388554293i/331920._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/331920.Flipped",
+    rating: 3.98,
+  },
+  {
+    title: "The Summoning (Darkest Powers, #1)",
+    author: "Kelley Armstrong",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1478986944i/2800905._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/2800905-the-summoning",
+    rating: 4.02,
+  },
+  {
+    title: "The Absolutely True Diary of a Part-Time Indian",
+    author: "Sherman Alexie",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1327908992i/693208._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/693208.The_Absolutely_True_Diary_of_a_Part_Time_Indian",
+    rating: 4.07,
+  },
+  {
+    title: "The Lovely Bones",
+    author: "Alice Sebold",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1457810586i/12232938._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/12232938-the-lovely-bones",
+    rating: 3.85,
+  },
+  {
+    title: "Evermore (The Immortals, #1)",
+    author: "Alyson Noel",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1362336360i/3975774._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/3975774-evermore",
+    rating: 3.59,
+  },
+  {
+    title: "Among the Hidden (Shadow Children, #1)",
+    author: "Margaret Peterson Haddix",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1388382796i/227651._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/227651.Among_the_Hidden",
+    rating: 3.99,
+  },
+  {
+    title: "Mrs. Frisby and the Rats of NIMH (Rats of NIMH, #1)",
+    author: "Robert C. O'Brien",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1351191064i/9822._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/9822.Mrs_Frisby_and_the_Rats_of_NIMH",
+    rating: 4.16,
+  },
+  {
+    title: "The Princess Diaries (The Princess Diaries, #1)",
+    author: "Meg Cabot",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1355011082i/38980._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/38980.The_Princess_Diaries",
+    rating: 3.8,
+  },
+  {
+    title: "The Witch of Blackbird Pond",
+    author: "Elizabeth George Speare",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1345499790i/703292._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/703292.The_Witch_of_Blackbird_Pond",
+    rating: 4.02,
+  },
+  {
+    title: "Flowers in the Attic (Dollanganger, #1)",
+    author: "V.C. Andrews",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1327880853l/43448._SX50_SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/43448.Flowers_in_the_Attic",
+    rating: 3.85,
+  },
+  {
+    title: "The Chain Between Worlds (The Lost Artefacts #1)",
+    author: "Johnathon Nicolaou",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1643771474i/60288648._SX50_.jpg",
+    path: "https://www.goodreads.com/book/show/60288648-the-chain-between-worlds",
+    rating: 4.52,
+  },
+  {
+    title: "This Lullaby",
+    author: "Sarah Dessen",
+    cover:
+      "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1397779294i/22205._SY75_.jpg",
+    path: "https://www.goodreads.com/book/show/22205.This_Lullaby",
+    rating: 4.02,
+  },
+];

--- a/qa/playwright.config.ts
+++ b/qa/playwright.config.ts
@@ -13,6 +13,7 @@ import { defineConfig, devices } from "@playwright/test";
  */
 export default defineConfig({
   testDir: "./tests",
+  testIgnore: ["**/integration/**"],
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/qa/playwright.config.ts
+++ b/qa/playwright.config.ts
@@ -12,7 +12,7 @@ import { defineConfig, devices } from "@playwright/test";
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-  testDir: "./tests/browser",
+  testDir: "./tests",
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
@@ -26,7 +26,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://127.0.0.1:3000',
+    baseURL: "http://localhost:5173",
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",

--- a/qa/tests/accessibility/accessibility.spec.ts
+++ b/qa/tests/accessibility/accessibility.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+test.describe("homepage", () => {
+  // 2
+  test("should not have any automatically detectable accessibility issues", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+
+    expect(accessibilityScanResults.violations).toEqual([]);
+  });
+});

--- a/qa/tests/browser/books.ui.spec.ts
+++ b/qa/tests/browser/books.ui.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "@playwright/test";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("http://localhost:5173");
+  await page.goto("/");
 });
 
 test("has title", async ({ page }) => {


### PR DESCRIPTION
## What

This PR adds the axe-core library to the Playwright tests enabling us to automate some of our accessiblity testing.

https://playwright.dev/docs/accessibility-testing

## Why

This library will enable us to scan pages for WCAG violations automatically through a browser.

## Risk

⚠️ This change implements a second actions workflow in order to keep the accessiblity tests seperate. 
⚠️ This PR also makes a small update to the configuration of our integration tests using jest to ensure that they can be run in isolation.
⚠️ Auotmated accessiblity tests arel not able to catch all WCAG related vioaltion and manual testing will still be required.

## Additional  Comments

It is possible to cretae a seperate configuration file for this workflow in the future if it is needed.